### PR TITLE
Remove sts.txt from download list

### DIFF
--- a/src/jsattrak/utilities/TLEDownloader.java
+++ b/src/jsattrak/utilities/TLEDownloader.java
@@ -42,7 +42,7 @@ public class TLEDownloader implements java.io.Serializable
 	
 	// names of all TLE files to update
 	public String[] fileNames = new String[] {
-            "sts.txt",
+            // "sts.txt", removed, no more Space Shuttle flights :(
 			"stations.txt",
             "tle-new.txt", // added 26 Sept 2008 - SEG
             // "1999-025.txt",


### PR DESCRIPTION
As there are not more Space Shuttle flights, there is no need to download sts.txt, moreover the file no longer exist on the celestrak.com website causing log spam on their server and an sts.txt file on the client side filled with "wrong" data.